### PR TITLE
Added rudimentary support for `TaggedTemplateExpression`

### DIFF
--- a/src/values/expressions/TaggedTemplateExpression.js
+++ b/src/values/expressions/TaggedTemplateExpression.js
@@ -1,0 +1,9 @@
+import extractValueFromTemplateLiteral from './TemplateLiteral';
+
+/**
+ * Returns the string value of a tagged template literal object.
+ * Redirects the bulk of the work to `TemplateLiteral`.
+ */
+export default function extractValueFromTaggedTemplateExpression(value) {
+  return extractValueFromTemplateLiteral(value.quasi);
+}

--- a/src/values/expressions/index.js
+++ b/src/values/expressions/index.js
@@ -1,6 +1,7 @@
 import assign from 'object-assign';
 import Literal from '../Literal';
 import Identifier from './Identifier';
+import TaggedTemplateExpression from './TaggedTemplateExpression';
 import TemplateLiteral from './TemplateLiteral';
 import FunctionExpression from './FunctionExpression';
 import LogicalExpression from './LogicalExpression';
@@ -17,6 +18,7 @@ import NewExpression from './NewExpression';
 const TYPES = {
   Identifier,
   Literal,
+  TaggedTemplateExpression,
   TemplateLiteral,
   ArrowFunctionExpression: FunctionExpression,
   FunctionExpression,

--- a/tests/src/getPropLiteralValue.js
+++ b/tests/src/getPropLiteralValue.js
@@ -149,6 +149,26 @@ describe('getLiteralPropValue', () => {
     });
   });
 
+  describe('Tagged Template literal', () => {
+    it('should return template literal with vars wrapped in curly braces', () => {
+      const prop = extractProp('<div foo={noop`bar ${baz}`} />');
+
+      const expected = 'bar {baz}';
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should drop variables in template literals that are literally undefined', () => {
+      const prop = extractProp('<div foo={noop`bar ${undefined}`} />');
+
+      const expected = 'bar ';
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
   describe('Arrow function expression', () => {
     it('should return null', () => {
       const prop = extractProp('<div foo={ () => { return "bar"; }} />');

--- a/tests/src/getPropValue.js
+++ b/tests/src/getPropValue.js
@@ -221,6 +221,44 @@ describe('getPropValue', () => {
     });
   });
 
+  describe('Tagged Template literal', () => {
+    it('should return template literal with vars wrapped in curly braces', () => {
+      const prop = extractProp('<div foo={noop`bar ${baz}`} />');
+
+      const expected = 'bar {baz}';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should drop variables in template literals that are literally undefined', () => {
+      const prop = extractProp('<div foo={noop`bar ${undefined}`} />');
+
+      const expected = 'bar ';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return template literal with expression type wrapped in curly braces', () => {
+      const prop = extractProp('<div foo={noop`bar ${baz()}`} />');
+
+      const expected = 'bar {CallExpression}';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should ignore non-expressions in the template literal', () => {
+      const prop = extractProp('<div foo={noop`bar ${<baz />}`} />');
+
+      const expected = 'bar ';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
   describe('Arrow function expression', () => {
     it('should return a function', () => {
       const prop = extractProp('<div foo={ () => { return "bar"; }} />');


### PR DESCRIPTION
I most likely got this completely wrong, I'm far from being an AST connoisseur. At least, this prevents a crash in the meantime. It totally ignores the template tag, I'm not sure if there is a better way around that statically.