### PR TITLE
Move `acorn-jsx` to `devDependencies`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:watch": "npm test -- --watch"
   },
   "devDependencies": {
+    "acorn-jsx": "^3.0.1",
     "babel-cli": "^6.14.0",
     "babel-core": "^6.14.0",
     "babel-eslint": "^7.0.0",
@@ -43,7 +44,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "acorn-jsx": "^3.0.1",
     "object-assign": "^4.1.0"
   },
   "jest": {


### PR DESCRIPTION
Correct me if I am wrong, but it does not seem to be used [outside of tests](https://github.com/evcohen/jsx-ast-utils/blob/efff839e8be73e2028837284de51f9f8b37ce7cf/__tests__/helper.js#L3).