### PR TITLE
Only include built files in the NPM published package.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,4 @@
 node_modules
 reports
-npm-debug.log
 coverage
 .gitignore
-.DS_Store

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.3.5",
   "description": "AST utility module for statically analyzing JSX",
   "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "build": "rimraf lib && babel src --out-dir lib",
     "prepublish": "npm run lint && npm run test && npm run build",


### PR DESCRIPTION
In response to #18 

Sets files in the package.json to: lib

I tested the package with npm pack. The resulting package contained the following:

```
CHANGELOG.md
LICENSE.md
README.md
lib
package.json
```