### PR TITLE
Remove `object-assign`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
     "url": "https://github.com/evcohen/jsx-ast-utils"
   },
   "license": "MIT",
-  "dependencies": {
-    "object-assign": "^4.1.0"
-  },
   "jest": {
     "coverageReporters": [
       "lcov"


### PR DESCRIPTION
It was still listed as a dependency after https://github.com/evcohen/jsx-ast-utils/commit/93fdce184b3b8778c424986ca54d0284ec02f6ef.