### PR TITLE
Fixing fatal throw in getPropValue for ArrowFunctionExpression

### DIFF
--- a/__tests__/src/getPropValue-test.js
+++ b/__tests__/src/getPropValue-test.js
@@ -272,6 +272,17 @@ describe('getPropValue', () => {
       // For code coverage ¯\_(ツ)_/¯
       actual();
     });
+    it('should handle ArrowFunctionExpression as conditional consequent', () => {
+      const prop = extractProp('<div foo={ (true) ? () => null : () => ({})} />');
+
+      const expected = 'function';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, typeof actual);
+
+      // For code coverage ¯\_(ツ)_/¯
+      actual();
+    });
   });
 
   describe('Function expression', () => {

--- a/src/values/expressions/index.js
+++ b/src/values/expressions/index.js
@@ -94,7 +94,16 @@ const errorMessage = expression =>
  */
 export default function extract(value) {
   // Value will not have the expression property when we recurse.
-  const expression = value.expression || value;
+  // The type for expression on ArrowFunctionExpression is a boolean.
+  let expression;
+  if (
+    typeof value.expression !== 'boolean'
+    && value.expression
+  ) {
+    expression = value.expression;
+  } else {
+    expression = value;
+  }
   const { type } = expression;
 
   if (TYPES[type] === undefined) {


### PR DESCRIPTION
I ran into this lovely little fatal while running a jsx-a11y rule. Seems super edge-casey, and yet, it blew up my eslint run :) I think solution should work. I added a test case.

<img width="1380" alt="expression-is-boolean" src="https://cloud.githubusercontent.com/assets/345913/25167732/82773538-2495-11e7-8b24-438a099dd7be.png">
