### PR TITLE
propName should always return a value

### DIFF
--- a/__tests__/src/eventHandlers-test.js
+++ b/__tests__/src/eventHandlers-test.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 import assert from 'assert';
+import includes from 'array-includes';
 import eventHandlers, { eventHandlersByType } from '../../src/eventHandlers';
 
 describe('eventHandlers', () => {
@@ -74,7 +75,7 @@ describe('eventHandlers', () => {
       'onAnimationEnd',
       'onAnimationIteration',
       'onTransitionEnd',
-    ].every(handlerName => eventHandlers.includes(handlerName)));
+    ].every(handlerName => includes(eventHandlers, handlerName)));
   });
 });
 

--- a/__tests__/src/propName-test.js
+++ b/__tests__/src/propName-test.js
@@ -36,19 +36,4 @@ describe('propName', () => {
 
     assert.equal(expected, actual);
   });
-
-  // Note: this shouldn't happen, but safe guard anyway.
-  it('should return undefined if prop name is not JSXIdentifier or JSXNamespacedName', () => {
-    const prop = {
-      type: 'JSXAttribute',
-      name: {
-        type: 'Literal',
-      },
-    };
-
-    const expected = undefined;
-    const actual = propName(prop);
-
-    assert.equal(expected, actual);
-  });
 });

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
       "/node_modules/",
       "helper.js"
     ]
+  },
+  "dependencies": {
+    "array-includes": "^3.0.3"
   }
 }

--- a/src/propName.js
+++ b/src/propName.js
@@ -6,12 +6,9 @@ export default function propName(prop = {}) {
     throw new Error('The prop must be a JSXAttribute collected by the AST parser.');
   }
 
-  switch (prop.name.type) {
-    case 'JSXIdentifier':
-      return prop.name.name;
-    case 'JSXNamespacedName':
-      return `${prop.name.namespace.name}:${prop.name.name.name}`;
-    default:
-      return undefined;
+  if (prop.name.type === 'JSXNamespacedName') {
+    return `${prop.name.namespace.name}:${prop.name.name.name}`;
   }
+
+  return prop.name.name;
 }


### PR DESCRIPTION
Currently, the return value of `propName` is nullable. It should be able to guarantee a return value all the time.