### PR TITLE
Adding support for `objectRestSpread` within props

### DIFF
--- a/__tests__/helper.js
+++ b/__tests__/helper.js
@@ -4,7 +4,7 @@ const parser = require('babylon');
 
 function parse(code) {
   return parser.parse(code, {
-    plugins: ['jsx', 'functionBind', 'estree'],
+    plugins: ['jsx', 'functionBind', 'estree', 'objectRestSpread'],
   });
 }
 

--- a/__tests__/src/getPropValue-test.js
+++ b/__tests__/src/getPropValue-test.js
@@ -768,6 +768,15 @@ describe('getPropValue', () => {
 
       assert.deepEqual(expected, actual);
     });
+
+    it('should evaluate to a correct representation of the object, ignore spread properties', () => {
+      const prop = extractProp('<div foo={{bar: "baz", ...{baz: "bar", foo: {...{bar: "meh"}}}}} />');
+
+      const expected = { bar: 'baz', baz: 'bar', foo: { bar: 'meh' } };
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
   });
 
   describe('New expression', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coursera/jsx-ast-utils",
-  "version": "2.0.2-jnwng-0",
+  "version": "2.0.2-jnwng-1",
   "description": "AST utility module for statically analyzing JSX",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@coursera/jsx-ast-utils",
+  "name": "jsx-ast-utils",
   "version": "2.0.2-0",
   "description": "AST utility module for statically analyzing JSX",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jsx-ast-utils",
+  "name": "@coursera/jsx-ast-utils",
   "version": "2.0.2-jnwng-0",
   "description": "AST utility module for statically analyzing JSX",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coursera/jsx-ast-utils",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "AST utility module for statically analyzing JSX",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coursera/jsx-ast-utils",
-  "version": "2.0.2-jnwng-1",
+  "version": "2.0.2",
   "description": "AST utility module for statically analyzing JSX",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-ast-utils",
-  "version": "2.0.2-0",
+  "version": "2.0.2-jnwng-0",
   "description": "AST utility module for statically analyzing JSX",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-ast-utils",
-  "version": "2.0.2-0",
+  "version": "2.0.2",
   "description": "AST utility module for statically analyzing JSX",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coursera/jsx-ast-utils",
-  "version": "2.0.1",
+  "version": "2.0.2-0",
   "description": "AST utility module for statically analyzing JSX",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-ast-utils",
-  "version": "2.0.1",
+  "version": "2.0.2-0",
   "description": "AST utility module for statically analyzing JSX",
   "main": "lib/index.js",
   "scripts": {

--- a/src/values/expressions/ObjectExpression.js
+++ b/src/values/expressions/ObjectExpression.js
@@ -9,7 +9,13 @@ import getValue from './index';
 export default function extractValueFromObjectExpression(value) {
   return value.properties.reduce((obj, property) => {
     const object = Object.assign({}, obj);
-    object[getValue(property.key)] = getValue(property.value);
+    if (property.type === 'SpreadProperty') {
+      if (property.argument.type === 'ObjectExpression') {
+        return Object.assign(object, extractValueFromObjectExpression(property.argument));
+      }
+    } else {
+      object[getValue(property.key)] = getValue(property.value);
+    }
     return object;
   }, {});
 }


### PR DESCRIPTION
We hit at an issue properly parsing props that looked like

```jsx
<div foo={{ params: {...router.params}}} />
```

because the SpreadProperty doesn't have a key/value pair. Opting to ignore spread properties, but properly recurse over the key/values we _can_ parse.