### PR TITLE
Support ExperimentalSpreadProperty inside an ObjectExpression

### DIFF
--- a/__tests__/helper.js
+++ b/__tests__/helper.js
@@ -1,6 +1,6 @@
 import getProp from '../src/getProp';
 
-const parser = require('babylon');
+const parser = require('@babel/parser');
 
 function parse(code) {
   return parser.parse(code, {

--- a/__tests__/src/getPropValue-test.js
+++ b/__tests__/src/getPropValue-test.js
@@ -768,6 +768,15 @@ describe('getPropValue', () => {
 
       assert.deepEqual(expected, actual);
     });
+
+    it('should evaluate to a correct representation of the object with spread in props', () => {
+      const prop = extractProp('<div foo={{ ...spread }} />');
+
+      const expected = { spread: 'spread' };
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
   });
 
   describe('New expression', () => {

--- a/__tests__/src/getPropValue-test.js
+++ b/__tests__/src/getPropValue-test.js
@@ -777,6 +777,15 @@ describe('getPropValue', () => {
 
       assert.deepEqual(expected, actual);
     });
+
+    it('should evaluate to a correct representation of the object with identifier in props', () => {
+      const prop = extractProp('<div foo={{ identifier }} />');
+
+      const expected = { identifier: 'identifier' };
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
   });
 
   describe('New expression', () => {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-jest": "^20.0.0",
     "babel-polyfill": "^6.16.0",
     "babel-preset-es2015": "^6.14.0",
-    "babylon": "^6.17.2",
+    "@babel/parser": "^7.3.3",
     "coveralls": "^2.11.8",
     "eslint": "^3.12.1",
     "eslint-config-airbnb-base": "^11.1.0",

--- a/src/values/expressions/ObjectExpression.js
+++ b/src/values/expressions/ObjectExpression.js
@@ -9,7 +9,13 @@ import getValue from './index';
 export default function extractValueFromObjectExpression(value) {
   return value.properties.reduce((obj, property) => {
     const object = Object.assign({}, obj);
-    object[getValue(property.key)] = getValue(property.value);
+
+    // The 'ExperimentalSpreadProperty' only has an `argument` property, rather
+    // than a `key` and `value`.
+    const propKey = property.key || property.argument;
+    const propValue = property.value || property.argument;
+
+    object[getValue(propKey)] = getValue(propValue);
     return object;
   }, {});
 }


### PR DESCRIPTION
E.g.: `{ ...spread }`

`ExperimentalSpreadProperty` only has an 'argument' property, rather than a 'key' or 'value', causing #69. Using the  'argument' property results in an extracted value similar to an `Identifier` inside an object (`{ identifier }`).

Fixes #69.