### PR TITLE
[evcohen/eslint-plugin-jsx-a11y#399] Accommodate ExperimentalSpreadProperty in prop values

### DIFF
--- a/__tests__/src/getPropValue-test.js
+++ b/__tests__/src/getPropValue-test.js
@@ -777,6 +777,15 @@ describe('getPropValue', () => {
 
       assert.deepEqual(expected, actual);
     });
+
+    it('should evaluate to a correct representation of the object, ignore spread properties', () => {
+      const prop = extractProp('<div foo={{ pathname: manageRoute, state: {...data}}} />');
+
+      const expected = { pathname: 'manageRoute', state: {} };
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
   });
 
   describe('New expression', () => {

--- a/src/values/expressions/ObjectExpression.js
+++ b/src/values/expressions/ObjectExpression.js
@@ -9,7 +9,8 @@ import getValue from './index';
 export default function extractValueFromObjectExpression(value) {
   return value.properties.reduce((obj, property) => {
     const object = Object.assign({}, obj);
-    if (property.type === 'SpreadProperty') {
+    // Support types: SpreadProperty and ExperimentalSpreadProperty
+    if (/^(?:Experimental)?SpreadProperty$/.test(property.type)) {
       if (property.argument.type === 'ObjectExpression') {
         return Object.assign(object, extractValueFromObjectExpression(property.argument));
       }


### PR DESCRIPTION
A pattern like this:

```
<Link to={{ pathname: manageRoute, state: {...data}}} />
```

Will cause `ObjectExpression` to throw an error. This diff properly treats `ExperimentalSpreadProperty` as a `SpreadProperty`.