### PR TITLE
[#73] Account for SpreadElement AST Nodes

### DIFF
--- a/__tests__/src/getPropValue-test.js
+++ b/__tests__/src/getPropValue-test.js
@@ -808,6 +808,15 @@ describe('getPropValue', () => {
 
       assert.deepEqual(expected, actual);
     });
+
+    it('should evaluate to a correct representation of an array with spread elements', () => {
+      const prop = extractProp('<div foo={[...this.props.params, bar]} />');
+
+      const expected = [undefined, 'bar'];
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
   });
 
   it('should return an empty array provided an empty array in props', () => {

--- a/src/values/expressions/SpreadElement.js
+++ b/src/values/expressions/SpreadElement.js
@@ -1,0 +1,11 @@
+/**
+ * Extractor function for a SpreadElement type value node.
+ * We can't statically evaluate an array spread, so just return
+ * undefined.
+ *
+ * @param - value - AST Value object with type `SpreadElement`
+ * @returns - An prototypeless object.
+ */
+export default function extractValueFromSpreadElement() {
+  return undefined;
+}

--- a/src/values/expressions/index.js
+++ b/src/values/expressions/index.js
@@ -16,6 +16,7 @@ import NewExpression from './NewExpression';
 import UpdateExpression from './UpdateExpression';
 import ArrayExpression from './ArrayExpression';
 import BindExpression from './BindExpression';
+import SpreadElement from './SpreadElement';
 
 // Composition map of types to their extractor functions.
 const TYPES = {
@@ -38,6 +39,7 @@ const TYPES = {
   UpdateExpression,
   ArrayExpression,
   BindExpression,
+  SpreadElement,
 };
 
 const noop = () => null;
@@ -79,6 +81,7 @@ const LITERAL_TYPES = Object.assign({}, TYPES, {
     return extractedVal.filter(val => val !== null);
   },
   BindExpression: noop,
+  SpreadElement: noop,
 });
 
 const errorMessage = expression =>


### PR DESCRIPTION
Account for array `SpreadElement` nodes.

```
<div foo={[...this.props.params, bar]} />
```