### PR TITLE
[evcohen/jsx-ast-utils#70] Support OptionalMemberExpression AST nodes

### DIFF
--- a/__tests__/helper.js
+++ b/__tests__/helper.js
@@ -4,7 +4,13 @@ const parser = require('babylon');
 
 function parse(code) {
   return parser.parse(code, {
-    plugins: ['jsx', 'functionBind', 'estree', 'objectRestSpread'],
+    plugins: [
+      'estree',
+      'functionBind',
+      'jsx',
+      'objectRestSpread',
+      'optionalChaining',
+    ],
   });
 }
 

--- a/__tests__/src/getPropLiteralValue-test.js
+++ b/__tests__/src/getPropLiteralValue-test.js
@@ -258,7 +258,7 @@ describe('getLiteralPropValue', () => {
 
       // -"bar" => NaN
       const expected = true;
-      const actual = isNaN(getLiteralPropValue(prop));
+      const actual = Number.isNaN(getLiteralPropValue(prop));
 
       assert.equal(expected, actual);
     });
@@ -277,7 +277,7 @@ describe('getLiteralPropValue', () => {
 
       // +"bar" => NaN
       const expected = true;
-      const actual = isNaN(getLiteralPropValue(prop));
+      const actual = Number.isNaN(getLiteralPropValue(prop));
 
       assert.equal(expected, actual);
     });
@@ -344,7 +344,7 @@ describe('getLiteralPropValue', () => {
 
       // ++"bar" => NaN
       const expected = true;
-      const actual = isNaN(getLiteralPropValue(prop));
+      const actual = Number.isNaN(getLiteralPropValue(prop));
 
       assert.equal(expected, actual);
     });
@@ -354,7 +354,7 @@ describe('getLiteralPropValue', () => {
 
       // --"bar" => NaN
       const expected = true;
-      const actual = isNaN(getLiteralPropValue(prop));
+      const actual = Number.isNaN(getLiteralPropValue(prop));
 
       assert.equal(expected, actual);
     });
@@ -364,7 +364,7 @@ describe('getLiteralPropValue', () => {
 
       // "bar"++ => NaN
       const expected = true;
-      const actual = isNaN(getLiteralPropValue(prop));
+      const actual = Number.isNaN(getLiteralPropValue(prop));
 
       assert.equal(expected, actual);
     });
@@ -374,7 +374,7 @@ describe('getLiteralPropValue', () => {
 
       // "bar"-- => NaN
       const expected = true;
-      const actual = isNaN(getLiteralPropValue(prop));
+      const actual = Number.isNaN(getLiteralPropValue(prop));
 
       assert.equal(expected, actual);
     });

--- a/__tests__/src/getPropValue-test.js
+++ b/__tests__/src/getPropValue-test.js
@@ -355,6 +355,20 @@ describe('getPropValue', () => {
 
       assert.equal(expected, actual);
     });
+
+    it('should evaluate to a correct representation of member expression with a nullable member', () => {
+      // This tell will not throw when Babel is upgraded from 6 to 7. Remove
+      // the throw expectation wrapper at that time.
+      // eslint-disable-next-line no-undef
+      expect(() => {
+        const prop = extractProp('<div foo={bar?.baz} />');
+
+        const expected = 'bar?.baz';
+        const actual = getPropValue(prop);
+
+        assert.equal(expected, actual);
+      }).toThrow();
+    });
   });
 
   describe('Call expression', () => {
@@ -383,7 +397,7 @@ describe('getPropValue', () => {
 
       // -"bar" => NaN
       const expected = true;
-      const actual = isNaN(getPropValue(prop));
+      const actual = Number.isNaN(getPropValue(prop));
 
       assert.equal(expected, actual);
     });
@@ -402,7 +416,7 @@ describe('getPropValue', () => {
 
       // +"bar" => NaN
       const expected = true;
-      const actual = isNaN(getPropValue(prop));
+      const actual = Number.isNaN(getPropValue(prop));
 
       assert.equal(expected, actual);
     });
@@ -469,7 +483,7 @@ describe('getPropValue', () => {
 
       // ++"bar" => NaN
       const expected = true;
-      const actual = isNaN(getPropValue(prop));
+      const actual = Number.isNaN(getPropValue(prop));
 
       assert.equal(expected, actual);
     });
@@ -478,7 +492,7 @@ describe('getPropValue', () => {
       const prop = extractProp('<div foo={--bar} />');
 
       const expected = true;
-      const actual = isNaN(getPropValue(prop));
+      const actual = Number.isNaN(getPropValue(prop));
 
       assert.equal(expected, actual);
     });
@@ -488,7 +502,7 @@ describe('getPropValue', () => {
 
       // "bar"++ => NaN
       const expected = true;
-      const actual = isNaN(getPropValue(prop));
+      const actual = Number.isNaN(getPropValue(prop));
 
       assert.equal(expected, actual);
     });
@@ -497,7 +511,7 @@ describe('getPropValue', () => {
       const prop = extractProp('<div foo={bar--} />');
 
       const expected = true;
-      const actual = isNaN(getPropValue(prop));
+      const actual = Number.isNaN(getPropValue(prop));
 
       assert.equal(expected, actual);
     });

--- a/elementType.js
+++ b/elementType.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib').elementType;  // eslint-disable-line import/no-unresolved
+module.exports = require('./lib').elementType; // eslint-disable-line import/no-unresolved

--- a/src/elementType.js
+++ b/src/elementType.js
@@ -19,7 +19,9 @@ export default function elementType(node = {}) {
   if (name.type === 'JSXMemberExpression') {
     const { object = {}, property = {} } = name;
     return resolveMemberExpressions(object, property);
-  } else if (name.type === 'JSXNamespacedName') {
+  }
+
+  if (name.type === 'JSXNamespacedName') {
     return `${name.namespace.name}:${name.name.name}`;
   }
 

--- a/src/getProp.js
+++ b/src/getProp.js
@@ -18,9 +18,9 @@ export default function getProp(props = [], prop = '', options = DEFAULT_OPTIONS
       return false;
     }
 
-    const currentProp = options.ignoreCase ?
-      propName(attribute).toUpperCase() :
-      propName(attribute);
+    const currentProp = options.ignoreCase
+      ? propName(attribute).toUpperCase()
+      : propName(attribute);
 
     return propToFind === currentProp;
   });

--- a/src/hasProp.js
+++ b/src/hasProp.js
@@ -18,9 +18,9 @@ export default function hasProp(props = [], prop = '', options = DEFAULT_OPTIONS
       return !options.spreadStrict;
     }
 
-    const currentProp = options.ignoreCase ?
-      propName(attribute).toUpperCase() :
-      propName(attribute);
+    const currentProp = options.ignoreCase
+      ? propName(attribute).toUpperCase()
+      : propName(attribute);
 
     return propToCheck === currentProp;
   });

--- a/src/values/Literal.js
+++ b/src/values/Literal.js
@@ -10,7 +10,9 @@ export default function extractValueFromLiteral(value) {
   const normalizedStringValue = typeof extractedValue === 'string' && extractedValue.toLowerCase();
   if (normalizedStringValue === 'true') {
     return true;
-  } else if (normalizedStringValue === 'false') {
+  }
+
+  if (normalizedStringValue === 'false') {
     return false;
   }
 

--- a/src/values/expressions/ArrayExpression.js
+++ b/src/values/expressions/ArrayExpression.js
@@ -1,5 +1,3 @@
-import getValue from './index';
-
 /**
  * Extractor function for an ArrayExpression type value node.
  * An array expression is an expression with [] syntax.
@@ -7,5 +5,7 @@ import getValue from './index';
  * @returns - An array of the extracted elements.
  */
 export default function extractValueFromArrayExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
   return value.elements.map(element => getValue(element));
 }

--- a/src/values/expressions/BinaryExpression.js
+++ b/src/values/expressions/BinaryExpression.js
@@ -1,6 +1,3 @@
-import getValue from './index';
-
-
 /**
  * Extractor function for a BinaryExpression type value node.
  * A binary expression has a left and right side separated by an operator
@@ -10,6 +7,8 @@ import getValue from './index';
  * @returns - The extracted value converted to correct type.
  */
 export default function extractValueFromBinaryExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
   const { operator, left, right } = value;
   const leftVal = getValue(left);
   const rightVal = getValue(right);

--- a/src/values/expressions/BindExpression.js
+++ b/src/values/expressions/BindExpression.js
@@ -1,5 +1,3 @@
-import getValue from './index';
-
 /**
  * Extractor function for a BindExpression type value node.
  * A bind expression looks like `::this.foo`
@@ -10,7 +8,8 @@ import getValue from './index';
  * @returns - The extracted value converted to correct type.
  */
 export default function extractValueFromBindExpression(value) {
-  // console.log(value);
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
   const callee = getValue(value.callee);
 
   // If value.object === null, the callee must be a MemberExpression.

--- a/src/values/expressions/CallExpression.js
+++ b/src/values/expressions/CallExpression.js
@@ -1,5 +1,3 @@
-import getValue from './index';
-
 /**
  * Extractor function for a CallExpression type value node.
  * A call expression looks like `bar()`
@@ -10,5 +8,7 @@ import getValue from './index';
  * @returns - The extracted value converted to correct type.
  */
 export default function extractValueFromCallExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
   return getValue(value.callee);
 }

--- a/src/values/expressions/ConditionalExpression.js
+++ b/src/values/expressions/ConditionalExpression.js
@@ -1,5 +1,3 @@
-import getValue from './index';
-
 /**
  * Extractor function for a ConditionalExpression type value node.
  *
@@ -7,6 +5,8 @@ import getValue from './index';
  * @returns - The extracted value converted to correct type.
  */
 export default function extractValueFromConditionalExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
   const {
     test,
     alternate,

--- a/src/values/expressions/LogicalExpression.js
+++ b/src/values/expressions/LogicalExpression.js
@@ -1,5 +1,3 @@
-import getValue from './index';
-
 /**
  * Extractor function for a LogicalExpression type value node.
  * A logical expression is `a && b` or `a || b`, so we evaluate both sides
@@ -9,6 +7,8 @@ import getValue from './index';
  * @returns - The extracted value converted to correct type.
  */
 export default function extractValueFromLogicalExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
   const { operator, left, right } = value;
   const leftVal = getValue(left);
   const rightVal = getValue(right);

--- a/src/values/expressions/MemberExpression.js
+++ b/src/values/expressions/MemberExpression.js
@@ -1,5 +1,3 @@
-import getValue from './index';
-
 /**
  * Extractor function for a MemberExpression type value node.
  * A member expression is accessing a property on an object `obj.property`.
@@ -9,5 +7,7 @@ import getValue from './index';
  *  and maintaing `obj.property` convention.
  */
 export default function extractValueFromMemberExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
   return `${getValue(value.object)}.${getValue(value.property)}`;
 }

--- a/src/values/expressions/ObjectExpression.js
+++ b/src/values/expressions/ObjectExpression.js
@@ -1,5 +1,3 @@
-import getValue from './index';
-
 /**
  * Extractor function for an ObjectExpression type value node.
  * An object expression is using {}.
@@ -7,10 +5,12 @@ import getValue from './index';
  * @returns - a representation of the object
  */
 export default function extractValueFromObjectExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
   return value.properties.reduce((obj, property) => {
     const object = Object.assign({}, obj);
     // Support types: SpreadProperty and ExperimentalSpreadProperty
-    if (/^(?:Experimental)?SpreadProperty$/.test(property.type)) {
+    if (/^(?:Experimental)?Spread(?:Property|Element)$/.test(property.type)) {
       if (property.argument.type === 'ObjectExpression') {
         return Object.assign(object, extractValueFromObjectExpression(property.argument));
       }

--- a/src/values/expressions/OptionalMemberExpression.js
+++ b/src/values/expressions/OptionalMemberExpression.js
@@ -1,0 +1,13 @@
+/**
+ * Extractor function for a OptionalMemberExpression type value node.
+ * A member expression is accessing a property on an object `obj.property`.
+ *
+ * @param - value - AST Value object with type `OptionalMemberExpression`
+ * @returns - The extracted value converted to correct type
+ *  and maintaing `obj?.property` convention.
+ */
+export default function extractValueFromOptionalMemberExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
+  return `${getValue(value.object)}?.${getValue(value.property)}`;
+}

--- a/src/values/expressions/TemplateLiteral.js
+++ b/src/values/expressions/TemplateLiteral.js
@@ -19,9 +19,13 @@ export default function extractValueFromTemplateLiteral(value) {
     } = part;
     if (type === 'TemplateElement') {
       return raw + part.value.raw;
-    } else if (type === 'Identifier') {
+    }
+
+    if (type === 'Identifier') {
       return part.name === 'undefined' ? `${raw}${part.name}` : `${raw}{${part.name}}`;
-    } else if (type.indexOf('Expression') > -1) {
+    }
+
+    if (type.indexOf('Expression') > -1) {
       return `${raw}{${type}}`;
     }
 

--- a/src/values/expressions/UnaryExpression.js
+++ b/src/values/expressions/UnaryExpression.js
@@ -1,5 +1,3 @@
-import getValue from './index';
-
 /**
  * Extractor function for a UnaryExpression type value node.
  * A unary expression is an expression with a unary operator.
@@ -9,6 +7,8 @@ import getValue from './index';
  * @returns - The extracted value converted to correct type.
  */
 export default function extractValueFromUnaryExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
   const { operator, argument } = value;
 
   switch (operator) {

--- a/src/values/expressions/UpdateExpression.js
+++ b/src/values/expressions/UpdateExpression.js
@@ -1,5 +1,3 @@
-import getValue from './index';
-
 /**
  * Extractor function for an UpdateExpression type value node.
  * An update expression is an expression with an update operator.
@@ -9,6 +7,8 @@ import getValue from './index';
  * @returns - The extracted value converted to correct type.
  */
 export default function extractValueFromUpdateExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
   const { operator, argument, prefix } = value;
 
   let val = getValue(argument);


### PR DESCRIPTION
Support patterns like

```
<div foo={b?.c?.d;} />
```

I made the ESLint changes necessary to upgrade from Babel 6 to Babel 7, although the kept the old dependencies. The upgrade should be easy and now it'll be easier to test locally with Babel 7 and not get a ton of ESLint warnings (because ESLint will upgrade as well and start complaining about cyclical imports).