### PR TITLE
Stop throwing errors when unknown AST nodes are encountered

### DIFF
--- a/__tests__/src/getPropLiteralValue-test.js
+++ b/__tests__/src/getPropLiteralValue-test.js
@@ -19,7 +19,7 @@ describe('getLiteralPropValue', () => {
     assert.equal(expected, actual);
   });
 
-  it('should throw error when trying to get value from unknown node type', () => {
+  it('should not throw error when trying to get value from unknown node type', () => {
     const prop = {
       type: 'JSXAttribute',
       value: {
@@ -27,9 +27,11 @@ describe('getLiteralPropValue', () => {
       },
     };
 
-    assert.throws(() => {
+    assert.doesNotThrow(() => {
       getLiteralPropValue(prop);
     }, Error);
+
+    assert.equal(null, getLiteralPropValue(prop));
   });
 
   describe('Null', () => {

--- a/__tests__/src/getPropValue-test.js
+++ b/__tests__/src/getPropValue-test.js
@@ -32,9 +32,11 @@ describe('getPropValue', () => {
       },
     };
 
-    assert.throws(() => {
+    assert.doesNotThrow(() => {
       getPropValue(prop);
     }, Error);
+
+    assert.equal(null, getPropValue(prop));
   });
 
   describe('Null', () => {

--- a/src/values/expressions/index.js
+++ b/src/values/expressions/index.js
@@ -80,7 +80,9 @@ export default function extract(value) {
   }
 
   if (TYPES[type] === undefined) {
-    throw new Error(errorMessage(type));
+    // eslint-disable-next-line no-console
+    console.error(errorMessage(type));
+    return null;
   }
 
   return TYPES[type](expression);
@@ -145,7 +147,9 @@ export function extractLiteral(value) {
   const { type } = expression;
 
   if (LITERAL_TYPES[type] === undefined) {
-    throw new Error(errorMessage(type));
+    // eslint-disable-next-line no-console
+    console.error(errorMessage(type));
+    return null;
   }
 
   return LITERAL_TYPES[type](expression);


### PR DESCRIPTION
Rather than chase down every new AST Node type, this module should just not throw when it encounters them. It doesn't need to throw; the error isn't one that should stop the program's execution. 