### PR TITLE
Account for TypeCastExpression in the utils

### DIFF
--- a/__tests__/helper.js
+++ b/__tests__/helper.js
@@ -5,10 +5,16 @@ const nodeVersion = parseInt(process.version.match(/^v(\d+)\./)[1], 10);
 
 export const fallbackToBabylon = nodeVersion < 6;
 
-const parser = fallbackToBabylon ? require('babylon') : require('@babel/parser');
+let parserName;
+const babelParser = fallbackToBabylon ? require('babylon') : require('@babel/parser');
+const flowParser = require('flow-parser');
 
 const defaultPlugins = ['jsx', 'functionBind', 'estree', 'objectRestSpread', 'optionalChaining'];
 let plugins = [...defaultPlugins];
+
+export function setParserName(name) {
+  parserName = name;
+}
 
 export function changePlugins(pluginOrFn) {
   if (Array.isArray(pluginOrFn)) {
@@ -25,11 +31,43 @@ beforeEach(() => {
 });
 
 function parse(code) {
-  return parser.parse(code, { plugins });
+  if (parserName === undefined) {
+    throw new Error('No parser specified');
+  }
+  if (parserName === 'babel') {
+    try {
+      return babelParser.parse(code, { plugins });
+    } catch (_) {
+      // eslint-disable-next-line no-console
+      console.warn(`Failed to parse with ${fallbackToBabylon ? 'babylon' : 'Babel'} parser.`);
+    }
+  }
+  if (parserName === 'flow') {
+    try {
+      return flowParser.parse(code, { plugins });
+    } catch (_) {
+      // eslint-disable-next-line no-console
+      console.warn('Failed to parse with the Flow parser');
+    }
+  }
+  throw new Error(`The parser ${parserName} is not yet supported for testing.`);
 }
 
 export function getOpeningElement(code) {
-  return parse(code).program.body[0].expression.openingElement;
+  const parsedCode = parse(code);
+  let body;
+  if (parsedCode.program) {
+    // eslint-disable-next-line prefer-destructuring
+    body = parsedCode.program.body;
+  } else {
+    // eslint-disable-next-line prefer-destructuring
+    body = parsedCode.body;
+  }
+  if (Array.isArray(body) && body[0] != null) {
+    return body[0].expression.openingElement;
+  }
+
+  return null;
 }
 
 export function extractProp(code, prop = 'foo') {

--- a/__tests__/src/elementType-test.js
+++ b/__tests__/src/elementType-test.js
@@ -1,9 +1,12 @@
 /* eslint-env mocha */
 import assert from 'assert';
-import { getOpeningElement } from '../helper';
+import { getOpeningElement, setParserName } from '../helper';
 import elementType from '../../src/elementType';
 
 describe('elementType tests', () => {
+  beforeEach(() => {
+    setParserName('babel');
+  });
   it('should export a function', () => {
     const expected = 'function';
     const actual = typeof elementType;

--- a/__tests__/src/getProp-test.js
+++ b/__tests__/src/getProp-test.js
@@ -1,9 +1,12 @@
 /* eslint-env mocha */
 import assert from 'assert';
-import { getOpeningElement } from '../helper';
+import { getOpeningElement, setParserName } from '../helper';
 import getProp from '../../src/getProp';
 
 describe('getProp', () => {
+  beforeEach(() => {
+    setParserName('babel');
+  });
   it('should export a function', () => {
     const expected = 'function';
     const actual = typeof getProp;

--- a/__tests__/src/getPropLiteralValue-babelparser-test.js
+++ b/__tests__/src/getPropLiteralValue-babelparser-test.js
@@ -1,10 +1,18 @@
 /* eslint-env mocha */
 /* eslint no-template-curly-in-string: 0 */
 import assert from 'assert';
-import { extractProp, describeIfNotBabylon, changePlugins } from '../helper';
+import {
+  extractProp,
+  describeIfNotBabylon,
+  changePlugins,
+  setParserName,
+} from '../helper';
 import { getLiteralPropValue } from '../../src/getPropValue';
 
 describe('getLiteralPropValue', () => {
+  beforeEach(() => {
+    setParserName('babel');
+  });
   it('should export a function', () => {
     const expected = 'function';
     const actual = typeof getLiteralPropValue;
@@ -26,12 +34,22 @@ describe('getLiteralPropValue', () => {
         type: 'JSXExpressionContainer',
       },
     };
-
+    let counter = 0;
+    // eslint-disable-next-line no-console
+    const errorOrig = console.error;
+    // eslint-disable-next-line no-console
+    console.error = () => {
+      counter += 1;
+    };
+    let value;
     assert.doesNotThrow(() => {
-      getLiteralPropValue(prop);
+      value = getLiteralPropValue(prop);
     }, Error);
 
-    assert.equal(null, getLiteralPropValue(prop));
+    assert.equal(null, value);
+    assert.equal(counter, 1);
+    // eslint-disable-next-line no-console
+    console.error = errorOrig;
   });
 
   describe('Null', () => {
@@ -121,7 +139,7 @@ describe('getLiteralPropValue', () => {
 
   describe('JSXElement', () => {
     it('should return null', () => {
-      const prop = extractProp('<div foo=<bar /> />');
+      const prop = extractProp('<div foo={<bar />} />');
 
       const expected = null;
       const actual = getLiteralPropValue(prop);

--- a/__tests__/src/getPropLiteralValue-flowparser-test.js
+++ b/__tests__/src/getPropLiteralValue-flowparser-test.js
@@ -1,0 +1,522 @@
+/* eslint-env mocha */
+/* eslint no-template-curly-in-string: 0 */
+import assert from 'assert';
+import {
+  extractProp,
+  describeIfNotBabylon,
+  changePlugins,
+  setParserName,
+} from '../helper';
+import { getLiteralPropValue } from '../../src/getPropValue';
+
+describe('getLiteralPropValue', () => {
+  beforeEach(() => {
+    setParserName('flow');
+  });
+  it('should export a function', () => {
+    const expected = 'function';
+    const actual = typeof getLiteralPropValue;
+
+    assert.equal(expected, actual);
+  });
+
+  it('should return undefined when not provided with a JSXAttribute', () => {
+    const expected = undefined;
+    const actual = getLiteralPropValue(1);
+
+    assert.equal(expected, actual);
+  });
+
+  it('should not throw error when trying to get value from unknown node type', () => {
+    const prop = {
+      type: 'JSXAttribute',
+      value: {
+        type: 'JSXExpressionContainer',
+      },
+    };
+    let counter = 0;
+    // eslint-disable-next-line no-console
+    const errorOrig = console.error;
+    // eslint-disable-next-line no-console
+    console.error = () => {
+      counter += 1;
+    };
+    let value;
+    assert.doesNotThrow(() => {
+      value = getLiteralPropValue(prop);
+    }, Error);
+
+    assert.equal(null, value);
+    assert.equal(counter, 1);
+    // eslint-disable-next-line no-console
+    console.error = errorOrig;
+  });
+
+  describe('Null', () => {
+    it('should return true when no value is given', () => {
+      const prop = extractProp('<div foo />');
+
+      const expected = true;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Literal', () => {
+    it('should return correct string if value is a string', () => {
+      const prop = extractProp('<div foo="bar" />');
+
+      const expected = 'bar';
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return correct string if value is a string expression', () => {
+      const prop = extractProp('<div foo={"bar"} />');
+
+      const expected = 'bar';
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return correct integer if value is a integer expression', () => {
+      const prop = extractProp('<div foo={1} />');
+
+      const expected = 1;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should convert "true" to boolean type', () => {
+      const prop = extractProp('<div foo="true" />');
+
+      const expected = true;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should convert "TrUE" to boolean type', () => {
+      const prop = extractProp('<div foo="TrUE" />');
+
+      const expected = true;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should convert "false" to boolean type', () => {
+      const prop = extractProp('<div foo="false" />');
+
+      const expected = false;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should convert "FaLsE" to boolean type', () => {
+      const prop = extractProp('<div foo="FaLsE" />');
+
+      const expected = false;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return String null when value is null', () => {
+      const prop = extractProp('<div foo={null} />');
+
+      const expected = 'null';
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('JSXElement', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={<bar />} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Identifier', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={bar} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return undefined when identifier is literally `undefined`', () => {
+      const prop = extractProp('<div foo={undefined} />');
+
+      const expected = undefined;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Template literal', () => {
+    it('should return template literal with vars wrapped in curly braces', () => {
+      const prop = extractProp('<div foo={`bar ${baz}`} />');
+
+      const expected = 'bar {baz}';
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return string "undefined" for expressions that evaluate to undefined', () => {
+      const prop = extractProp('<div foo={`bar ${undefined}`} />');
+
+      const expected = 'bar undefined';
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Tagged Template literal', () => {
+    it('should return template literal with vars wrapped in curly braces', () => {
+      const prop = extractProp('<div foo={noop`bar ${baz}`} />');
+
+      const expected = 'bar {baz}';
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return string "undefined" for expressions that evaluate to undefined', () => {
+      const prop = extractProp('<div foo={noop`bar ${undefined}`} />');
+
+      const expected = 'bar undefined';
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Arrow function expression', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={ () => { return "bar"; }} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Function expression', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={ function() { return "bar"; } } />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Logical expression', () => {
+    it('should return null for && operator', () => {
+      const prop = extractProp('<div foo={bar && baz} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return null for || operator', () => {
+      const prop = extractProp('<div foo={bar || baz} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Member expression', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={bar.baz} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Call expression', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={bar()} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Unary expression', () => {
+    it('should correctly evaluate an expression that prefixes with -', () => {
+      const prop = extractProp('<div foo={-bar} />');
+
+      // -"bar" => NaN
+      const expected = true;
+      const actual = Number.isNaN(getLiteralPropValue(prop));
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that prefixes with -', () => {
+      const prop = extractProp('<div foo={-42} />');
+
+      const expected = -42;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that prefixes with +', () => {
+      const prop = extractProp('<div foo={+bar} />');
+
+      // +"bar" => NaN
+      const expected = true;
+      const actual = Number.isNaN(getLiteralPropValue(prop));
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that prefixes with +', () => {
+      const prop = extractProp('<div foo={+42} />');
+
+      const expected = 42;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that prefixes with !', () => {
+      const prop = extractProp('<div foo={!bar} />');
+
+      const expected = false; // !"bar" === false
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that prefixes with ~', () => {
+      const prop = extractProp('<div foo={~bar} />');
+
+      const expected = -1; // ~"bar" === -1
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return true when evaluating `delete foo`', () => {
+      const prop = extractProp('<div foo={delete x} />');
+
+      const expected = true;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return undefined when evaluating `void foo`', () => {
+      const prop = extractProp('<div foo={void x} />');
+
+      const expected = undefined;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    // TODO: We should fix this to check to see if we can evaluate it.
+    it('should return undefined when evaluating `typeof foo`', () => {
+      const prop = extractProp('<div foo={typeof x} />');
+
+      const expected = undefined;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Update expression', () => {
+    it('should correctly evaluate an expression that prefixes with ++', () => {
+      const prop = extractProp('<div foo={++bar} />');
+
+      // ++"bar" => NaN
+      const expected = true;
+      const actual = Number.isNaN(getLiteralPropValue(prop));
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that prefixes with --', () => {
+      const prop = extractProp('<div foo={--bar} />');
+
+      // --"bar" => NaN
+      const expected = true;
+      const actual = Number.isNaN(getLiteralPropValue(prop));
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that suffixes with ++', () => {
+      const prop = extractProp('<div foo={bar++} />');
+
+      // "bar"++ => NaN
+      const expected = true;
+      const actual = Number.isNaN(getLiteralPropValue(prop));
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that suffixes with --', () => {
+      const prop = extractProp('<div foo={bar--} />');
+
+      // "bar"-- => NaN
+      const expected = true;
+      const actual = Number.isNaN(getLiteralPropValue(prop));
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('This expression', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={this} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Conditional expression', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={bar ? baz : bam} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Binary expression', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={1 == "1"} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Object expression', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={ { bar: "baz" } } />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
+  });
+
+  describe('New expression', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={new Bar()} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
+  });
+
+  describe('Array expression', () => {
+    it('should evaluate to correct representation of the the array in props', () => {
+      const prop = extractProp('<div foo={["bar", 42, null]} />');
+
+      const expected = ['bar', 42];
+      const actual = getLiteralPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
+  });
+
+  it('should return an empty array provided an empty array in props', () => {
+    const prop = extractProp('<div foo={[]} />');
+
+    const expected = [];
+    const actual = getLiteralPropValue(prop);
+
+    assert.deepEqual(expected, actual);
+  });
+
+  describe('Bind expression', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={::this.handleClick} />');
+
+      const expected = 'null';
+      const actual = getLiteralPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
+  });
+
+  describeIfNotBabylon('Typescript', () => {
+    beforeEach(() => {
+      changePlugins(pls => [...pls, 'typescript']);
+    });
+
+    it('should return string representation of variable identifier wrapped in a Typescript non-null assertion', () => {
+      const prop = extractProp('<div foo={bar!} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return string representation of variable identifier wrapped in a deep Typescript non-null assertion', () => {
+      const prop = extractProp('<div foo={(bar!)!} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return string representation of variable identifier wrapped in a Typescript type coercion', () => {
+      changePlugins(pls => [...pls, 'typescript']);
+      const prop = extractProp('<div foo={bar as any} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+});

--- a/__tests__/src/getPropValue-flowparser-test.js
+++ b/__tests__/src/getPropValue-flowparser-test.js
@@ -1,0 +1,938 @@
+/* eslint-env mocha */
+/* eslint no-template-curly-in-string: 0 */
+import assert from 'assert';
+import {
+  extractProp,
+  changePlugins,
+  describeIfNotBabylon,
+  setParserName,
+} from '../helper';
+import getPropValue from '../../src/getPropValue';
+
+describe('getPropValue', () => {
+  beforeEach(() => {
+    setParserName('flow');
+  });
+  it('should export a function', () => {
+    const expected = 'function';
+    const actual = typeof getPropValue;
+
+    assert.equal(expected, actual);
+  });
+
+  it('should return undefined when not provided with a JSXAttribute', () => {
+    const expected = undefined;
+    const actual = getPropValue(1);
+
+    assert.equal(expected, actual);
+  });
+
+  it('should throw not error when trying to get value from unknown node type', () => {
+    const prop = {
+      type: 'JSXAttribute',
+      value: {
+        type: 'JSXExpressionContainer',
+      },
+    };
+    let counter = 0;
+    // eslint-disable-next-line no-console
+    const errorOrig = console.error;
+    // eslint-disable-next-line no-console
+    console.error = () => {
+      counter += 1;
+    };
+    let value;
+    assert.doesNotThrow(() => {
+      value = getPropValue(prop);
+    }, Error);
+
+    assert.equal(null, value);
+    assert.equal(counter, 1);
+    // eslint-disable-next-line no-console
+    console.error = errorOrig;
+  });
+
+  describe('Null', () => {
+    it('should return true when no value is given', () => {
+      const prop = extractProp('<div foo />');
+
+      const expected = true;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Literal', () => {
+    it('should return correct string if value is a string', () => {
+      const prop = extractProp('<div foo="bar" />');
+
+      const expected = 'bar';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return correct string if value is a string expression', () => {
+      const prop = extractProp('<div foo={"bar"} />');
+
+      const expected = 'bar';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return correct integer if value is a integer expression', () => {
+      const prop = extractProp('<div foo={1} />');
+
+      const expected = 1;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should convert "true" to boolean type', () => {
+      const prop = extractProp('<div foo="true" />');
+
+      const expected = true;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should convert "false" to boolean type', () => {
+      const prop = extractProp('<div foo="false" />');
+
+      const expected = false;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('JSXElement', () => {
+    it('should return correct representation of JSX element as a string', () => {
+      const prop = extractProp('<div foo={<bar />} />');
+
+      const expected = '<bar />';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Identifier', () => {
+    it('should return string representation of variable identifier', () => {
+      const prop = extractProp('<div foo={bar} />');
+
+      const expected = 'bar';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return undefined when identifier is literally `undefined`', () => {
+      const prop = extractProp('<div foo={undefined} />');
+
+      const expected = undefined;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return String object when using a reserved JavaScript object', () => {
+      const prop = extractProp('<div foo={String} />');
+
+      const expected = String;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return Array object when using a reserved JavaScript object', () => {
+      const prop = extractProp('<div foo={Array} />');
+
+      const expected = Array;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return Date object when using a reserved JavaScript object', () => {
+      const prop = extractProp('<div foo={Date} />');
+
+      const expected = Date;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return Infinity object when using a reserved JavaScript object', () => {
+      const prop = extractProp('<div foo={Infinity} />');
+
+      const expected = Infinity;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return Math object when using a reserved JavaScript object', () => {
+      const prop = extractProp('<div foo={Math} />');
+
+      const expected = Math;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return Number object when using a reserved JavaScript object', () => {
+      const prop = extractProp('<div foo={Number} />');
+
+      const expected = Number;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return Object object when using a reserved JavaScript object', () => {
+      const prop = extractProp('<div foo={Object} />');
+
+      const expected = Object;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Template literal', () => {
+    it('should return template literal with vars wrapped in curly braces', () => {
+      const prop = extractProp('<div foo={`bar ${baz}`} />');
+
+      const expected = 'bar {baz}';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return string "undefined" for expressions that evaluate to undefined', () => {
+      const prop = extractProp('<div foo={`bar ${undefined}`} />');
+
+      const expected = 'bar undefined';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return template literal with expression type wrapped in curly braces', () => {
+      const prop = extractProp('<div foo={`bar ${baz()}`} />');
+
+      const expected = 'bar {CallExpression}';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should ignore non-expressions in the template literal', () => {
+      const prop = extractProp('<div foo={`bar ${<baz />}`} />');
+
+      const expected = 'bar ';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Tagged Template literal', () => {
+    it('should return template literal with vars wrapped in curly braces', () => {
+      const prop = extractProp('<div foo={noop`bar ${baz}`} />');
+
+      const expected = 'bar {baz}';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return string "undefined" for expressions that evaluate to undefined', () => {
+      const prop = extractProp('<div foo={noop`bar ${undefined}`} />');
+
+      const expected = 'bar undefined';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return template literal with expression type wrapped in curly braces', () => {
+      const prop = extractProp('<div foo={noop`bar ${baz()}`} />');
+
+      const expected = 'bar {CallExpression}';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should ignore non-expressions in the template literal', () => {
+      const prop = extractProp('<div foo={noop`bar ${<baz />}`} />');
+
+      const expected = 'bar ';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Arrow function expression', () => {
+    it('should return a function', () => {
+      const prop = extractProp('<div foo={ () => { return "bar"; }} />');
+
+      const expected = 'function';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, typeof actual);
+
+      // For code coverage ¯\_(ツ)_/¯
+      actual();
+    });
+    it('should handle ArrowFunctionExpression as conditional consequent', () => {
+      const prop = extractProp('<div foo={ (true) ? () => null : () => ({})} />');
+
+      const expected = 'function';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, typeof actual);
+
+      // For code coverage ¯\_(ツ)_/¯
+      actual();
+    });
+  });
+
+  describe('Function expression', () => {
+    it('should return a function', () => {
+      const prop = extractProp('<div foo={ function() { return "bar"; } } />');
+
+      const expected = 'function';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, typeof actual);
+
+      // For code coverage ¯\_(ツ)_/¯
+      actual();
+    });
+  });
+
+  describe('Logical expression', () => {
+    it('should correctly infer result of && logical expression based on derived values', () => {
+      const prop = extractProp('<div foo={bar && baz} />');
+
+      const expected = 'baz';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return undefined when evaluating `undefined && undefined` ', () => {
+      const prop = extractProp('<div foo={undefined && undefined} />');
+
+      const expected = undefined;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly infer result of || logical expression based on derived values', () => {
+      const prop = extractProp('<div foo={bar || baz} />');
+
+      const expected = 'bar';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly infer result of || logical expression based on derived values', () => {
+      const prop = extractProp('<div foo={undefined || baz} />');
+
+      const expected = 'baz';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return undefined when evaluating `undefined || undefined` ', () => {
+      const prop = extractProp('<div foo={undefined || undefined} />');
+
+      const expected = undefined;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Member expression', () => {
+    it('should return string representation of form `object.property`', () => {
+      const prop = extractProp('<div foo={bar.baz} />');
+
+      const expected = 'bar.baz';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate to a correct representation of member expression with a nullable member', () => {
+      const prop = extractProp('<div foo={bar?.baz} />');
+
+      const expected = 'bar?.baz';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Call expression', () => {
+    it('should return string representation of callee', () => {
+      const prop = extractProp('<div foo={bar()} />');
+
+      const expected = 'bar';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return string representation of callee', () => {
+      const prop = extractProp('<div foo={bar.call()} />');
+
+      const expected = 'bar.call';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Unary expression', () => {
+    it('should correctly evaluate an expression that prefixes with -', () => {
+      const prop = extractProp('<div foo={-bar} />');
+
+      // -"bar" => NaN
+      const expected = true;
+      const actual = Number.isNaN(getPropValue(prop));
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that prefixes with -', () => {
+      const prop = extractProp('<div foo={-42} />');
+
+      const expected = -42;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that prefixes with +', () => {
+      const prop = extractProp('<div foo={+bar} />');
+
+      // +"bar" => NaN
+      const expected = true;
+      const actual = Number.isNaN(getPropValue(prop));
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that prefixes with +', () => {
+      const prop = extractProp('<div foo={+42} />');
+
+      const expected = 42;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that prefixes with !', () => {
+      const prop = extractProp('<div foo={!bar} />');
+
+      const expected = false; // !"bar" === false
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that prefixes with ~', () => {
+      const prop = extractProp('<div foo={~bar} />');
+
+      const expected = -1; // ~"bar" === -1
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return true when evaluating `delete foo`', () => {
+      const prop = extractProp('<div foo={delete x} />');
+
+      const expected = true;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return undefined when evaluating `void foo`', () => {
+      const prop = extractProp('<div foo={void x} />');
+
+      const expected = undefined;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    // TODO: We should fix this to check to see if we can evaluate it.
+    it('should return undefined when evaluating `typeof foo`', () => {
+      const prop = extractProp('<div foo={typeof x} />');
+
+      const expected = undefined;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Update expression', () => {
+    it('should correctly evaluate an expression that prefixes with ++', () => {
+      const prop = extractProp('<div foo={++bar} />');
+
+      // ++"bar" => NaN
+      const expected = true;
+      const actual = Number.isNaN(getPropValue(prop));
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that prefixes with --', () => {
+      const prop = extractProp('<div foo={--bar} />');
+
+      const expected = true;
+      const actual = Number.isNaN(getPropValue(prop));
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that suffixes with ++', () => {
+      const prop = extractProp('<div foo={bar++} />');
+
+      // "bar"++ => NaN
+      const expected = true;
+      const actual = Number.isNaN(getPropValue(prop));
+
+      assert.equal(expected, actual);
+    });
+
+    it('should correctly evaluate an expression that suffixes with --', () => {
+      const prop = extractProp('<div foo={bar--} />');
+
+      const expected = true;
+      const actual = Number.isNaN(getPropValue(prop));
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('This expression', () => {
+    it('should return string value `this`', () => {
+      const prop = extractProp('<div foo={this} />');
+
+      const expected = 'this';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Conditional expression', () => {
+    it('should evaluate the conditional based on the derived values correctly', () => {
+      const prop = extractProp('<div foo={bar ? baz : bam} />');
+
+      const expected = 'baz';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the conditional based on the derived values correctly', () => {
+      const prop = extractProp('<div foo={undefined ? baz : bam} />');
+
+      const expected = 'bam';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the conditional based on the derived values correctly', () => {
+      const prop = extractProp('<div foo={(1 > 2) ? baz : bam} />');
+
+      const expected = 'bam';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Binary expression', () => {
+    it('should evaluate the `==` operator correctly', () => {
+      const trueProp = extractProp('<div foo={1 == "1"} />');
+      const falseProp = extractProp('<div foo={1 == bar} />');
+
+      const trueVal = getPropValue(trueProp);
+      const falseVal = getPropValue(falseProp);
+
+      assert.equal(true, trueVal);
+      assert.equal(false, falseVal);
+    });
+
+    it('should evaluate the `!=` operator correctly', () => {
+      const trueProp = extractProp('<div foo={1 != "2"} />');
+      const falseProp = extractProp('<div foo={1 != "1"} />');
+
+      const trueVal = getPropValue(trueProp);
+      const falseVal = getPropValue(falseProp);
+
+      assert.equal(true, trueVal);
+      assert.equal(false, falseVal);
+    });
+
+    it('should evaluate the `===` operator correctly', () => {
+      const trueProp = extractProp('<div foo={1 === 1} />');
+      const falseProp = extractProp('<div foo={1 === "1"} />');
+
+      const trueVal = getPropValue(trueProp);
+      const falseVal = getPropValue(falseProp);
+
+      assert.equal(true, trueVal);
+      assert.equal(false, falseVal);
+    });
+
+    it('should evaluate the `!==` operator correctly', () => {
+      const trueProp = extractProp('<div foo={1 !== "1"} />');
+      const falseProp = extractProp('<div foo={1 !== 1} />');
+
+      const trueVal = getPropValue(trueProp);
+      const falseVal = getPropValue(falseProp);
+
+      assert.equal(true, trueVal);
+      assert.equal(false, falseVal);
+    });
+
+    it('should evaluate the `<` operator correctly', () => {
+      const trueProp = extractProp('<div foo={1 < 2} />');
+      const falseProp = extractProp('<div foo={1 < 0} />');
+
+      const trueVal = getPropValue(trueProp);
+      const falseVal = getPropValue(falseProp);
+
+      assert.equal(true, trueVal);
+      assert.equal(false, falseVal);
+    });
+
+    it('should evaluate the `>` operator correctly', () => {
+      const trueProp = extractProp('<div foo={1 > 0} />');
+      const falseProp = extractProp('<div foo={1 > 2} />');
+
+      const trueVal = getPropValue(trueProp);
+      const falseVal = getPropValue(falseProp);
+
+      assert.equal(true, trueVal);
+      assert.equal(false, falseVal);
+    });
+
+    it('should evaluate the `<=` operator correctly', () => {
+      const trueProp = extractProp('<div foo={1 <= 1} />');
+      const falseProp = extractProp('<div foo={1 <= 0} />');
+
+      const trueVal = getPropValue(trueProp);
+      const falseVal = getPropValue(falseProp);
+
+      assert.equal(true, trueVal);
+      assert.equal(false, falseVal);
+    });
+
+    it('should evaluate the `>=` operator correctly', () => {
+      const trueProp = extractProp('<div foo={1 >= 1} />');
+      const falseProp = extractProp('<div foo={1 >= 2} />');
+
+      const trueVal = getPropValue(trueProp);
+      const falseVal = getPropValue(falseProp);
+
+      assert.equal(true, trueVal);
+      assert.equal(false, falseVal);
+    });
+
+    it('should evaluate the `<<` operator correctly', () => {
+      const prop = extractProp('<div foo={1 << 2} />');
+
+      const expected = 4;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `>>` operator correctly', () => {
+      const prop = extractProp('<div foo={1 >> 2} />');
+
+      const expected = 0;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `>>>` operator correctly', () => {
+      const prop = extractProp('<div foo={2 >>> 1} />');
+
+      const expected = 1;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `+` operator correctly', () => {
+      const prop = extractProp('<div foo={1 + 1} />');
+
+      const expected = 2;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `-` operator correctly', () => {
+      const prop = extractProp('<div foo={1 - 1} />');
+
+      const expected = 0;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `*` operator correctly', () => {
+      const prop = extractProp('<div foo={10 * 10} />');
+
+      const expected = 100;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `/` operator correctly', () => {
+      const prop = extractProp('<div foo={10 / 2} />');
+
+      const expected = 5;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `%` operator correctly', () => {
+      const prop = extractProp('<div foo={10 % 3} />');
+
+      const expected = 1;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `|` operator correctly', () => {
+      const prop = extractProp('<div foo={10 | 1} />');
+
+      const expected = 11;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `^` operator correctly', () => {
+      const prop = extractProp('<div foo={10 ^ 1} />');
+
+      const expected = 11;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `&` operator correctly', () => {
+      const prop = extractProp('<div foo={10 & 1} />');
+
+      const expected = 0;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `in` operator correctly', () => {
+      const prop = extractProp('<div foo={foo in bar} />');
+
+      const expected = false;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `instanceof` operator correctly', () => {
+      const prop = extractProp('<div foo={{} instanceof Object} />');
+
+      const expected = true;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should evaluate the `instanceof` operator when right side is not a function', () => {
+      const prop = extractProp('<div foo={"bar" instanceof Baz} />');
+
+      const expected = false;
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+
+  describe('Object expression', () => {
+    it('should evaluate to a correct representation of the object in props', () => {
+      const prop = extractProp('<div foo={ { bar: "baz" } } />');
+
+      const expected = { bar: 'baz' };
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
+
+    it('should evaluate to a correct representation of the object, ignore spread properties', () => {
+      const prop = extractProp('<div foo={{bar: "baz", ...{baz: "bar", foo: {...{bar: "meh"}}}}} />');
+
+      const expected = { bar: 'baz', baz: 'bar', foo: { bar: 'meh' } };
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
+
+    it('should evaluate to a correct representation of the object, ignore spread properties', () => {
+      const prop = extractProp('<div foo={{ pathname: manageRoute, state: {...data}}} />');
+
+      const expected = { pathname: 'manageRoute', state: {} };
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
+  });
+
+  describe('New expression', () => {
+    it('should return a new empty object', () => {
+      const prop = extractProp('<div foo={new Bar()} />');
+
+      const expected = {};
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
+  });
+
+  describe('Array expression', () => {
+    it('should evaluate to correct representation of the the array in props', () => {
+      const prop = extractProp('<div foo={["bar", 42, null]} />');
+
+      const expected = ['bar', 42, null];
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
+
+    it('should evaluate to a correct representation of an array with spread elements', () => {
+      const prop = extractProp('<div foo={[...this.props.params, bar]} />');
+
+      const expected = [undefined, 'bar'];
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
+  });
+
+  it('should return an empty array provided an empty array in props', () => {
+    const prop = extractProp('<div foo={[]} />');
+
+    const expected = [];
+    const actual = getPropValue(prop);
+
+    assert.deepEqual(expected, actual);
+  });
+
+  describe('Bind expression', () => {
+    it('should return string representation of bind function call when object is null', () => {
+      const prop = extractProp('<div foo={::this.handleClick} />');
+
+      const expected = null;
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should return string representation of bind function call when object is not null', () => {
+      const prop = extractProp('<div foo={foo::bar} />');
+
+      const expected = 'foo';
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should return string representation of bind function call when binding to object properties', () => {
+      const prop = extractProp('<div foo={a.b::c} />');
+      const otherProp = extractProp('<div foo={::a.b.c} />');
+
+      const expected = 'a.b';
+      const actual = getPropValue(prop);
+
+      const otherExpected = null;
+      const otherActual = getPropValue(otherProp);
+
+      assert.deepEqual(actual, expected);
+      assert.deepEqual(otherActual, otherExpected);
+    });
+  });
+
+  describe('Type Cast Expression', () => {
+    it('should return the expression from a type cast', () => {
+      const prop = extractProp('<div foo={(this.handleClick: (event: MouseEvent) => void))} />');
+
+      const expected = 'this.handleClick';
+      const actual = getPropValue(prop);
+
+      assert.deepEqual(expected, actual);
+    });
+  });
+
+  describeIfNotBabylon('Typescript', () => {
+    beforeEach(() => {
+      changePlugins(pls => [...pls, 'typescript']);
+    });
+
+    it('should return string representation of variable identifier wrapped in a Typescript non-null assertion', () => {
+      const prop = extractProp('<div foo={bar!} />');
+
+      const expected = 'bar';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return string representation of variable identifier wrapped in a deep Typescript non-null assertion', () => {
+      const prop = extractProp('<div foo={(bar!)!} />');
+
+      const expected = 'bar';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+
+    it('should return string representation of variable identifier wrapped in a Typescript type coercion', () => {
+      changePlugins(pls => [...pls, 'typescript']);
+      const prop = extractProp('<div foo={bar as any} />');
+
+      const expected = 'bar';
+      const actual = getPropValue(prop);
+
+      assert.equal(expected, actual);
+    });
+  });
+});

--- a/__tests__/src/hasProp-test.js
+++ b/__tests__/src/hasProp-test.js
@@ -1,9 +1,12 @@
 /* eslint-env mocha */
 import assert from 'assert';
-import { getOpeningElement } from '../helper';
+import { getOpeningElement, setParserName } from '../helper';
 import hasProp, { hasAnyProp, hasEveryProp } from '../../src/hasProp';
 
 describe('hasProp', () => {
+  beforeEach(() => {
+    setParserName('babel');
+  });
   it('should export a function', () => {
     const expected = 'function';
     const actual = typeof hasProp;

--- a/__tests__/src/propName-test.js
+++ b/__tests__/src/propName-test.js
@@ -1,9 +1,12 @@
 /* eslint-env mocha */
 import assert from 'assert';
-import { extractProp } from '../helper';
+import { extractProp, setParserName } from '../helper';
 import propName from '../../src/propName';
 
 describe('propName', () => {
+  beforeEach(() => {
+    setParserName('babel');
+  });
   it('should export a function', () => {
     const expected = 'function';
     const actual = typeof propName;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint": "^6.0.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.2",
+    "flow-parser": "^0.102.0",
     "in-publish": "^2.0.0",
     "jest": "^20.0.4",
     "jest-cli": "^20.0.4",

--- a/src/values/expressions/TypeCastExpression.js
+++ b/src/values/expressions/TypeCastExpression.js
@@ -1,0 +1,13 @@
+/**
+ * Extractor function for a TypeCastExpression type value node.
+ * A type cast expression looks like `(this.handleClick: (event: MouseEvent) => void))`
+ * This will return the expression `this.handleClick`.
+ *
+ * @param - value - AST Value object with type `TypeCastExpression`
+ * @returns - The extracted value converted to correct type.
+ */
+export default function extractValueFromTypeCastExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
+  return getValue(value.expression);
+}

--- a/src/values/expressions/index.js
+++ b/src/values/expressions/index.js
@@ -18,6 +18,7 @@ import UpdateExpression from './UpdateExpression';
 import ArrayExpression from './ArrayExpression';
 import BindExpression from './BindExpression';
 import SpreadElement from './SpreadElement';
+import TypeCastExpression from './TypeCastExpression';
 
 // Composition map of types to their extractor functions.
 const TYPES = {
@@ -42,6 +43,7 @@ const TYPES = {
   ArrayExpression,
   BindExpression,
   SpreadElement,
+  TypeCastExpression,
 };
 
 const noop = () => null;
@@ -129,6 +131,7 @@ const LITERAL_TYPES = Object.assign({}, TYPES, {
   SpreadElement: noop,
   TSNonNullExpression: noop,
   TSAsExpression: noop,
+  TypeCastExpression: noop,
 });
 
 /**


### PR DESCRIPTION
We need to test with the flow-parser to account for Flow casting syntax.

But the flow-parser doesn't parse `BindExpression` correctly. 

So I broke the `getPropValue` and `getPropLiteralValue` value tests into a Babel parser version and a Flow parser version.